### PR TITLE
S1637: install vmstore-0.1.3 as part of the migration

### DIFF
--- a/src/migrate-vm
+++ b/src/migrate-vm
@@ -268,10 +268,6 @@ try:
     #
     # Note that it does not work for SL5, but a working versions seems
     # to be on those VMs already.
-
-
-    # This doesn't work on SL5, but a new enough version will already
-    # be there.
     if os_type is not 'sl5':
         print "+++ Upgrade python setuptools"
         subprocess.check_call("chroot %s pip install --upgrade setuptools" \


### PR DESCRIPTION
The old version of vmsave (provided by the vmstore package) would wipe out the partitioning and bootloader that we install. vmstore-0.1.3 will now preserve this in the image correctly.

<a href="https://timer.scm.io/repos/539247016c0000fa0366445b/issues/5/create?referer=github" target="_blank">Log Time</a>
